### PR TITLE
The filterString do not get updated if user provides a filterString

### DIFF
--- a/tests/dummy/app/controllers/examples/block-usage.js
+++ b/tests/dummy/app/controllers/examples/block-usage.js
@@ -16,6 +16,9 @@ export default class BlockUsageController extends ExampleController {
   @tracked
   pageSize = 25;
 
+  @tracked
+  filterString = 'C';
+
   get columnsForSecondTable() {
     return this.columns.slice(2);
   }

--- a/tests/dummy/app/templates/examples/block-usage.hbs
+++ b/tests/dummy/app/templates/examples/block-usage.hbs
@@ -9,8 +9,13 @@
   @columns={{this.columns}}
   @themeInstance={{this.fw.themeInstance}}
   @multipleExpand={{true}}
+  @filterString={{this.filterString}}
   @multipleSelect={{true}} as |MT|>
-  <MT.GlobalFilter/>
+  <MT.GlobalFilter>
+    <label>
+      Search: <Input @type="text" @value={{MT.globalFilter}} {{on "input" MT.changeGlobalFilter}} />
+    </label> 
+  </MT.GlobalFilter>
   <MT.ColumnsDropdown/>
   <MT.Table as |Table|>
     <Table.Header as |Header|>


### PR DESCRIPTION
The filter do not get updated in this case, because of when the `get filterString` is evaluated the `this.args.filterString` always exists. So we can never get the updated value in the `filterString`

https://github.com/SparshithNR/ember-models-table/blob/9a501ab8fb5a59135000278039f1c584d9155b5d/addon/components/models-table.ts#L334-L341

We need to update this to move the `this.args.filterString` outside the `get`. 
If we want to update the `_filterString` when `this.args.filterString` changes, we should can use `trackedReset` from the [tracked-toolbox](https://github.com/tracked-tools/tracked-toolbox).
